### PR TITLE
fix(driver): make module-name a required argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Usage
 =====
 ::
 
-    python -m jschema_to_python [-h] -s SCHEMA_PATH -o OUTPUT_DIRECTORY [-m MODULE_NAME] -r ROOT_CLASS_NAME [-g HINTS_FILE_PATH] [-f] [-v]
+    python -m jschema_to_python [-h] -s SCHEMA_PATH -o OUTPUT_DIRECTORY -m MODULE_NAME -r ROOT_CLASS_NAME [-g HINTS_FILE_PATH] [-f] [-v]
 
     Generate source code for a set of Python classes from a JSON schema.
 

--- a/jschema_to_python/driver.py
+++ b/jschema_to_python/driver.py
@@ -34,6 +34,7 @@ def _init_parser():
         "-m",
         "--module-name",
         help="name of the module containing the object model classes",
+        required=True,
     )
     parser.add_argument(
         "-r",


### PR DESCRIPTION
Not including the module-name results in the following error:
```python
sh-5.0$ python -m jschema_to_python -s common/json/models/auth.model.json -r Auth -o common/json/auth -f -v
jschema_to_python: JSON schema to Python object model generator, version 1.2.3
Generating Python classes...
Traceback (most recent call last):
  File "/home/mohamed/.conda/envs/python/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/mohamed/.conda/envs/python/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/__main__.py", line 13, in <module>
    sys.exit(_main())
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/driver.py", line 14, in main
    generator.generate()
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/object_model_module_generator.py", line 21, in generate
    self.generate_init_file()
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/object_model_module_generator.py", line 30, in generate_init_file
    init_file_generator.generate()
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/init_file_generator.py", line 20, in generate
    self.write_import_statements()
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/init_file_generator.py", line 23, in write_import_statements
    self.write_import_statement(self.root_class_name)
  File "/home/mohamed/Code/corvum/polaris/.venv/lib/python3.7/site-packages/jschema_to_python/init_file_generator.py", line 40, in write_import_statement
    + class_name
TypeError: can only concatenate str (not "NoneType") to str
```